### PR TITLE
Moved struct definitions out of the implementation

### DIFF
--- a/include/raylib-aseprite.h
+++ b/include/raylib-aseprite.h
@@ -33,14 +33,51 @@
 #define INCLUDE_RAYLIB_ASEPRITE_H_
 
 #include "raylib.h" // NOLINT
+#include "cute_aseprite.h" // NOLINT
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-typedef struct Aseprite Aseprite;                                   // A loaded Aseprite file
-typedef struct AsepriteTag AsepriteTag;                             // A tag sprite animation within an Aseprite file
-typedef struct AsepriteSlice AsepriteSlice;                         // A slice is a defined region within the Asperite.
+/**
+ * Aseprite object containing a pointer to the ase_t* from cute_aseprite.h.
+ *
+ * @see LoadAseprite()
+ * @see UnloadAseprite()
+ */
+typedef struct Aseprite {
+    ase_t* ase;         // Pointer to the cute_aseprite data.
+} Aseprite;
+
+/**
+ * Tag information from an Aseprite object.
+ *
+ * @see LoadAsepriteTag()
+ * @see LoadAsepriteTagFromIndex()
+ */
+typedef struct AsepriteTag {
+    char* name;         // The name of the tag.
+    int currentFrame;   // The frame that the tag is currently on
+    float timer;        // The countdown timer in seconds
+    int direction;      // Whether we are moving forwards, or backwards through the frames
+    float speed;        // The animation speed factor (1 is normal speed, 2 is double speed)
+    Color color;        // The color provided for the tag
+    bool loop;          // Whether to continue to play the animation when the animation finishes
+    bool paused;        // Set to true to not progression of the animation
+    Aseprite aseprite;  // The loaded Aseprite file
+    ase_tag_t* tag;     // The active tag to act upon
+} AsepriteTag;
+
+/**
+ * Slice data for the Aseprite.
+ *
+ * @see LoadAsepriteSlice()
+ * @see https://www.aseprite.org/docs/slices/
+ */
+typedef struct AsepriteSlice {
+    char* name;         // The name of the slice.
+    Rectangle bounds;   // The rectangle outer bounds for the slice.
+} AsepriteSlice;
 
 // Aseprite functions
 Aseprite LoadAseprite(const char* fileName);                        // Load an .aseprite file
@@ -113,46 +150,6 @@ extern "C" {
 #define CUTE_ASEPRITE_FCLOSE(fp) TraceLog(LOG_ERROR, "ASEPRITE: fclose() was removed")
 
 #include "cute_aseprite.h" // NOLINT
-
-/**
- * Aseprite object containing a pointer to the ase_t* from cute_aseprite.h.
- *
- * @see LoadAseprite()
- * @see UnloadAseprite()
- */
-struct Aseprite {
-    ase_t* ase;         // Pointer to the cute_aseprite data.
-};
-
-/**
- * Tag information from an Aseprite object.
- *
- * @see LoadAsepriteTag()
- * @see LoadAsepriteTagFromIndex()
- */
-struct AsepriteTag {
-    char* name;         // The name of the tag.
-    int currentFrame;   // The frame that the tag is currently on
-    float timer;        // The countdown timer in seconds
-    int direction;      // Whether we are moving forwards, or backwards through the frames
-    float speed;        // The animation speed factor (1 is normal speed, 2 is double speed)
-    Color color;        // The color provided for the tag
-    bool loop;          // Whether to continue to play the animation when the animation finishes
-    bool paused;        // Set to true to not progression of the animation
-    Aseprite aseprite;  // The loaded Aseprite file
-    ase_tag_t* tag;     // The active tag to act upon
-};
-
-/**
- * Slice data for the Aseprite.
- *
- * @see LoadAsepriteSlice()
- * @see https://www.aseprite.org/docs/slices/
- */
-struct AsepriteSlice {
-    char* name;         // The name of the slice.
-    Rectangle bounds;   // The rectangle outer bounds for the slice.
-};
 
 /**
  * Load an .aseprite file through its memory data.


### PR DESCRIPTION
I found that I couldn't use the Aseprite struct as a type for a field in one of my structs without defining the implementation which caused an error because I already had defined the implementation in my main file.

If I just didn't define the implementation I would get the following error:
```
Field has incomplete type 'Aseprite' (aka 'struct Aseprite')clang(field_incomplete_or_sizeless)
raylib_aseprite.h(41, 16): Forward declaration of 'struct Aseprite'
```

My solution was to pull the struct definitions out of the implementation block.