### PR TITLE
Added extern C to cute aseprite.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ int main() {
 
     while(!WindowShouldClose()) {
         // Update the animation frame.
-        UpdateAsperiteTag(&walkdown);
+        UpdateAsepriteTag(&walkdown);
 
         BeginDrawing();
         {

--- a/include/cute_aseprite.h
+++ b/include/cute_aseprite.h
@@ -98,6 +98,10 @@
 #ifndef CUTE_ASEPRITE_H
 #define CUTE_ASEPRITE_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct ase_t ase_t;
 
 ase_t* cute_aseprite_load_from_file(const char* path, void* mem_ctx);
@@ -306,11 +310,19 @@ struct ase_t
 	void* mem_ctx;
 };
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif // CUTE_ASEPRITE_H
 
 #ifdef CUTE_ASEPRITE_IMPLEMENTATION
 #ifndef CUTE_ASEPRITE_IMPLEMENTATION_ONCE
 #define CUTE_ASEPRITE_IMPLEMENTATION_ONCE
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #ifndef _CRT_SECURE_NO_WARNINGS
 	#define _CRT_SECURE_NO_WARNINGS
@@ -1313,6 +1325,10 @@ void cute_aseprite_free(ase_t* ase)
 	CUTE_ASEPRITE_FREE(ase->frames, ase->mem_ctx);
 	CUTE_ASEPRITE_FREE(ase, ase->mem_ctx);
 }
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // CUTE_ASEPRITE_IMPLEMENTATION_ONCE
 #endif // CUTE_ASEPRITE_IMPLEMENTATION


### PR DESCRIPTION
What it says in the title. Alternatively the include of cute aseprite in `raylib-aseprite.h` could be moved into the extern C block.

Before:
<img width="1507" height="447" alt="image" src="https://github.com/user-attachments/assets/454e433a-6729-4130-bede-4a0260cb6913" />

While I was at it I fixed a small typo in the readme.

Cheers.