### PR TITLE
Fix grayscale support by checking ase->mode

### DIFF
--- a/include/raylib-aseprite.h
+++ b/include/raylib-aseprite.h
@@ -201,17 +201,20 @@ Aseprite LoadAsepriteFromMemory(unsigned char* fileData, int size) {
         ImageDraw(&image, frameImage, src, dest, WHITE);
     }
 
-    // Apply the transparent pixel.
-    int transparency  = ase->transparent_palette_entry_index;
-    if (transparency >= 0 && transparency < ase->palette.entry_count) {
-        ase_color_t transparentColor = ase->palette.entries[transparency].color;
-        Color source = {
-            .r = transparentColor.r,
-            .g = transparentColor.g,
-            .b = transparentColor.b,
-            .a = transparentColor.a
-        };
-        ImageColorReplace(&image, source, BLANK);
+    // Apply the transparent pixel for indexed mode only.
+    // For RGBA and grayscale modes, transparency is already in the alpha channel.
+    if (ase->mode == ASE_MODE_INDEXED) {
+        int transparency = ase->transparent_palette_entry_index;
+        if (transparency >= 0 && transparency < ase->palette.entry_count) {
+            ase_color_t transparentColor = ase->palette.entries[transparency].color;
+            Color source = {
+                .r = transparentColor.r,
+                .g = transparentColor.g,
+                .b = transparentColor.b,
+                .a = transparentColor.a
+            };
+            ImageColorReplace(&image, source, BLANK);
+        }
     }
 
     // Create the Texture


### PR DESCRIPTION
Fixes #2

For RGBA and grayscale modes, pixel transparency is already embedded in the alpha channel by cute_aseprite. The palette-based `ImageColorReplace` only makes sense for indexed mode and was incorrectly applied to all modes.